### PR TITLE
feat: ユーザー情報取得失敗時のエラーハンドリングを大幅改善

### DIFF
--- a/twitter_blocker/manager.py
+++ b/twitter_blocker/manager.py
@@ -185,7 +185,7 @@ class BulkBlockManager:
                 user_info = self.api.get_user_info(user_identifier)
 
             if not user_info:
-                print("  ✗ エラー: ユーザー情報取得失敗")
+                print("  ✗ エラー: ユーザー情報取得失敗（詳細は上記ログを参照）")
                 stats["errors"] += 1
                 fallback_screen_name = (
                     str(user_identifier) if user_format == "screen_name" else None
@@ -250,7 +250,7 @@ class BulkBlockManager:
             user_info = self.api.get_user_info(screen_name)
 
             if not user_info:
-                print("  ✗ ユーザー情報取得失敗")
+                print("  ✗ ユーザー情報取得失敗（詳細は上記ログを参照）")
                 stats["errors"] += 1
                 self.database.record_block_result(
                     screen_name,


### PR DESCRIPTION
## Summary
- 詳細なエラーログ表示機能を追加（HTTPステータス、レート制限情報、GraphQLエラー詳細）
- レートリミット（429）検出時の自動15分待機とリトライ機能
- アカウントロック検出による処理自動終了機能
- ステータスコード別の分かりやすいエラーメッセージ表示

## 変更内容
### API層（twitter_blocker/api.py）
- `_log_response_details()`: レスポンス詳細のログ出力
- `_get_detailed_error_message()`: ステータスコード別の詳細エラーメッセージ生成
- `_is_account_locked()`: アカウントロック状態の検出
- レートリミット時の自動待機・リトライ処理

### マネージャー層（twitter_blocker/manager.py）
- エラー表示を「詳細は上記ログを参照」に変更し、API層の詳細ログと連携

## Test plan
- [x] 構文チェック完了
- [x] エラーハンドリングの動作確認完了
- [x] 認証エラー時の詳細表示確認

🤖 Generated with [Claude Code](https://claude.ai/code)