### PR TITLE
feat: 認証エラー（401）検出時に処理全体を終了

### DIFF
--- a/twitter_blocker/api.py
+++ b/twitter_blocker/api.py
@@ -64,6 +64,11 @@ class TwitterAPI:
                 )
                 self._log_response_details(response, screen_name, method_name="get_user_info_retry")
 
+            # 認証エラー検出
+            if response.status_code == 401:
+                print(f"認証エラー検出 ({screen_name}): Cookieが無効です。処理を終了します")
+                raise SystemExit("Authentication failed - Cookie is invalid")
+
             # アカウントロック検出
             if self._is_account_locked(response):
                 print(f"アカウントロック検出 ({screen_name}): 処理を終了します")
@@ -114,6 +119,11 @@ class TwitterAPI:
                     self.USER_BY_REST_ID_ENDPOINT, headers=headers, params=params
                 )
                 self._log_response_details(response, user_id, method_name="get_user_info_by_id_retry")
+
+            # 認証エラー検出
+            if response.status_code == 401:
+                print(f"認証エラー検出 (ID: {user_id}): Cookieが無効です。処理を終了します")
+                raise SystemExit("Authentication failed - Cookie is invalid")
 
             # アカウントロック検出
             if self._is_account_locked(response):


### PR DESCRIPTION
## Summary
- HTTP 401（認証エラー）検出時にSystemExitで処理を強制終了
- Cookieが無効な場合の明確なエラーメッセージ表示

## 変更内容
### API層（twitter_blocker/api.py）
- `get_user_info()` と `get_user_info_by_id()` にHTTP 401検出ロジックを追加
- 認証エラー時に「Cookieが無効です。処理を終了します」メッセージを表示してSystemExit

## Test plan
- [x] 構文チェック完了
- [x] 無効Cookieでの認証エラー時SystemExit動作確認済み

Closes #認証エラー時処理終了

🤖 Generated with [Claude Code](https://claude.ai/code)