### PR TITLE
feat: レート制限リセット時刻をAsia/Tokyoタイムゾーンで表示

### DIFF
--- a/twitter_blocker/api.py
+++ b/twitter_blocker/api.py
@@ -4,9 +4,15 @@ Twitter API アクセス管理モジュール
 
 import json
 import time
+from datetime import datetime
 from typing import Any, Dict, Optional
 
 import requests
+
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:
+    from backports.zoneinfo import ZoneInfo
 
 from .config import CookieManager
 
@@ -322,7 +328,14 @@ class TwitterAPI:
         if rate_limit_remaining is not None:
             print(f"  レート制限残り: {rate_limit_remaining}")
         if rate_limit_reset is not None:
-            print(f"  レート制限リセット: {rate_limit_reset}")
+            # UNIXタイムスタンプをAsia/Tokyoタイムゾーンで表示
+            try:
+                reset_timestamp = int(rate_limit_reset)
+                reset_datetime = datetime.fromtimestamp(reset_timestamp, tz=ZoneInfo("Asia/Tokyo"))
+                formatted_time = reset_datetime.strftime("%Y-%m-%d %H:%M:%S JST")
+                print(f"  レート制限リセット: {rate_limit_reset} ({formatted_time})")
+            except (ValueError, TypeError):
+                print(f"  レート制限リセット: {rate_limit_reset}")
 
         # エラー時の詳細情報
         if hasattr(response, 'status_code') and response.status_code >= 400:


### PR DESCRIPTION
## Summary
- レート制限リセットのUNIXタイムスタンプをAsia/Tokyoタイムゾーンで分かりやすく表示
- UNIXタイムスタンプと併せて 'YYYY-MM-DD HH:MM:SS JST' 形式で表示

## 変更内容
### API層（twitter_blocker/api.py）
- `_log_response_details()` メソッドにタイムゾーン変換機能を追加
- `zoneinfo`/`backports.zoneinfo` を使用してPython 3.8+対応
- 変換エラー時は元の値をそのまま表示（フォールバック）

## 表示例
```
レート制限リセット: 1750071402 (2025-06-16 19:56:42 JST)
```

## Test plan
- [x] 構文チェック完了
- [x] モックレスポンスでタイムゾーン変換動作確認済み

🤖 Generated with [Claude Code](https://claude.ai/code)