### PR TITLE
fix: ユーザーID取得の条件分岐ロジックを修正

### DIFF
--- a/twitter_blocker/api.py
+++ b/twitter_blocker/api.py
@@ -282,9 +282,8 @@ class TwitterAPI:
 
                 return {
                     "id": (
-                        legacy.get("id_str") or result.get("rest_id") or str(user_id)
-                        if user_id
-                        else None
+                        legacy.get("id_str") or result.get("rest_id") or 
+                        (str(user_id) if user_id else None)
                     ),
                     "screen_name": legacy.get("screen_name") or screen_name,
                     "name": legacy.get("name"),


### PR DESCRIPTION
## Summary
- 「DavidWr25625836」ユーザーでIDが取得できない問題を修正
- ID取得の条件分岐ロジックにあった論理エラーを解決

## 問題
```python
"id": (
    legacy.get("id_str") or result.get("rest_id") or str(user_id)
    if user_id  # ← この条件により、user_idがNoneの場合は常にNoneが返される
    else None
),
```

`get_user_info()` 呼び出し時は `user_id` が `None` のため、`legacy.id_str` や `result.rest_id` が存在していても常に `None` が返されていました。

## 修正内容
```python
"id": (
    legacy.get("id_str") or result.get("rest_id") or 
    (str(user_id) if user_id else None)
),
```

ID取得の優先順位を正しく適用：
1. `legacy.id_str` （最優先）
2. `result.rest_id` （フォールバック）
3. `user_id` （get_user_info_by_id呼び出し時のみ）

## Test plan
- [x] 構文チェック完了
- [x] 各種条件でのID取得テスト完了
  - legacy.id_str優先: ✓
  - rest_id使用: ✓
  - ID情報なし: ✓
  - DavidWr25625836シミュレート: ✓

## 影響
この修正により、表示名は取得できるがIDが取得できないユーザー（DavidWr25625836など）で正常にIDが取得されるようになります。

🤖 Generated with [Claude Code](https://claude.ai/code)