### PR TITLE
feat: ユーザー情報のJSONファイルキャッシュ機能を追加

### DIFF
--- a/twitter_blocker/api.py
+++ b/twitter_blocker/api.py
@@ -39,7 +39,7 @@ class TwitterAPI:
         self.cache_dir = Path(cache_dir)
         self.cache_dir.mkdir(parents=True, exist_ok=True)
         self.user_cache_file = self.cache_dir / "user_info_cache.json"
-        self.cache_ttl = 86400  # 24時間（秒）
+        self.cache_ttl = 2592000  # 30日間（秒）
 
     def get_user_info(self, screen_name: str) -> Optional[Dict[str, Any]]:
         """スクリーンネームからユーザー情報を取得"""
@@ -537,5 +537,5 @@ class TwitterAPI:
             "valid_entries": valid_entries,
             "expired_entries": expired_entries,
             "cache_file": str(self.user_cache_file),
-            "cache_ttl_hours": self.cache_ttl / 3600
+            "cache_ttl_days": self.cache_ttl / 86400
         }

--- a/twitter_blocker/manager.py
+++ b/twitter_blocker/manager.py
@@ -19,11 +19,12 @@ class BulkBlockManager:
         cookies_file: str = "cookies.json",
         users_file: str = "video_misuse_detecteds.json",
         db_file: str = "block_history.db",
+        cache_dir: str = "/data/cache",
     ):
         self.config_manager = ConfigManager(users_file)
         self.cookie_manager = CookieManager(cookies_file)
         self.database = DatabaseManager(db_file)
-        self.api = TwitterAPI(self.cookie_manager)
+        self.api = TwitterAPI(self.cookie_manager, cache_dir)
         self.retry_manager = RetryManager()
 
     def load_target_users(self) -> List[str]:


### PR DESCRIPTION
## Summary
- `get_user_info()` と `get_user_info_by_id()` の結果をJSONファイルでキャッシュ
- ボリューム永続化に対応したディレクトリ構造 (`/data/cache`)
- レートリミット軽減とAPI効率化を実現

## 変更内容
### API層（twitter_blocker/api.py）
- **キャッシュディレクトリ**: デフォルト `/data/cache` (ボリューム永続化対応)
- **TTL**: 30日間でキャッシュ自動期限切れ
- **キャッシュキー形式**:
  - `screen_name:ユーザー名` (get_user_info用)
  - `user_id:ユーザーID` (get_user_info_by_id用)

### キャッシュ機能
- `_load_cache()` / `_save_cache()`: JSONファイル読み書き
- `_get_from_cache()` / `_save_to_cache()`: TTL付きキャッシュ操作
- `clear_cache()`: キャッシュクリア
- `get_cache_stats()`: キャッシュ統計情報（日数単位表示）

### マネージャー層（twitter_blocker/manager.py）
- コンストラクタに `cache_dir` パラメータを追加
- 既存の使用箇所との後方互換性を維持

## キャッシュ動作
```
[CACHE HIT] DavidWr25625836: キャッシュからユーザー情報を取得
[CACHE SAVE] screen_name:DavidWr25625836: ユーザー情報をキャッシュに保存
[CACHE EXPIRED] screen_name:old_user: キャッシュが期限切れです
```

## ボリューム永続化対応
```yaml
volumes:
  - cache_data:/data/cache
```

## Test plan
- [x] 構文チェック完了
- [x] キャッシュ機能の動作テスト完了
  - ✓ キャッシュ保存・取得
  - ✓ TTL期限切れ
  - ✓ 統計情報取得
  - ✓ キャッシュクリア
- [x] 30日TTL設定確認完了

## 効果
- **レートリミット軽減**: 同一ユーザーの重複API呼び出しを削減
- **処理高速化**: キャッシュヒット時は即座に結果を返却
- **永続化**: コンテナ再起動後もキャッシュが保持される
- **長期キャッシュ**: 30日間の長期保存でさらなる効率化

🤖 Generated with [Claude Code](https://claude.ai/code)