### PR TITLE
feat: 認証エラー時のクッキー再読み込み機能を実装

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,111 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "twitter-blocker"
+version = "1.0.0"
+description = "Twitter/X.comで大量のユーザーを効率的にブロックするPythonツール"
+readme = "README.md"
+license = {text = "MIT"}
+authors = [
+    {name = "Author", email = "author@example.com"}
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: End Users/Desktop",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Communications :: Chat",
+    "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
+]
+dependencies = [
+    "requests>=2.31.0",
+    "pytz>=2023.3",
+]
+requires-python = ">=3.8"
+
+[project.urls]
+Homepage = "https://github.com/example/twitter-blocker"
+Repository = "https://github.com/example/twitter-blocker"
+Issues = "https://github.com/example/twitter-blocker/issues"
+
+[project.scripts]
+twitter-blocker = "twitter_blocker.__main__:main"
+
+[tool.setuptools.packages.find]
+include = ["twitter_blocker*"]
+
+[tool.setuptools.package-data]
+twitter_blocker = ["py.typed"]
+
+[tool.black]
+line-length = 88
+target-version = ['py38']
+include = '\.pyi?$'
+extend-exclude = '''
+/(
+  # directories
+  \.eggs
+  | \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | _build
+  | buck-out
+  | build
+  | dist
+  | archive
+)/
+'''
+
+[tool.isort]
+profile = "black"
+multi_line_output = 3
+line_length = 88
+known_first_party = ["twitter_blocker"]
+
+[tool.flake8]
+max-line-length = 88
+extend-ignore = ["E203", "W503"]
+exclude = [
+    ".git",
+    "__pycache__",
+    "build",
+    "dist",
+    "archive",
+    ".tox",
+    ".eggs",
+    "*.egg",
+]
+
+[tool.mypy]
+python_version = "3.8"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+check_untyped_defs = true
+disallow_untyped_decorators = true
+no_implicit_optional = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_no_return = true
+warn_unreachable = true
+strict_equality = true
+
+[[tool.mypy.overrides]]
+module = "requests.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "pytz.*"
+ignore_missing_imports = true

--- a/twitter_blocker/api.py
+++ b/twitter_blocker/api.py
@@ -50,6 +50,8 @@ class TwitterAPI:
         
         self.cache_ttl = 2592000  # 30日間（秒）
         self._login_user_id = None  # ログインユーザーIDのキャッシュ
+        self._auth_retry_count = 0  # 認証エラー時の再試行カウント
+        self._max_auth_retries = 1  # 最大認証再試行回数
 
     def _get_login_user_id(self) -> str:
         """ログインユーザーのIDを取得（キャッシュ用）"""
@@ -130,8 +132,8 @@ class TwitterAPI:
 
             # 認証エラー検出
             if response.status_code == 401:
-                print(f"認証エラー検出 ({screen_name}): Cookieが無効です。処理を終了します")
-                raise SystemExit("Authentication failed - Cookie is invalid")
+                return self._handle_auth_error(screen_name, "get_user_info", 
+                                               lambda: self.get_user_info(screen_name))
 
             # アカウントロック検出
             if self._is_account_locked(response):
@@ -203,8 +205,8 @@ class TwitterAPI:
 
             # 認証エラー検出
             if response.status_code == 401:
-                print(f"認証エラー検出 (ID: {user_id}): Cookieが無効です。処理を終了します")
-                raise SystemExit("Authentication failed - Cookie is invalid")
+                return self._handle_auth_error(user_id, "get_user_info_by_id", 
+                                               lambda: self.get_user_info_by_id(user_id))
 
             # アカウントロック検出
             if self._is_account_locked(response):
@@ -363,8 +365,8 @@ class TwitterAPI:
 
             # 認証エラー検出
             if response.status_code == 401:
-                print(f"認証エラー検出 (batch): Cookieが無効です。処理を終了します")
-                raise SystemExit("Authentication failed - Cookie is invalid")
+                return self._handle_auth_error(f"batch({len(user_ids)}users)", "get_users_batch", 
+                                               lambda: self._fetch_users_batch(user_ids))
 
             # アカウントロック検出
             if self._is_account_locked(response):
@@ -508,7 +510,8 @@ class TwitterAPI:
                 )
 
             if response.status_code == 401:
-                raise SystemExit("Authentication failed - Cookie is invalid")
+                return self._handle_auth_error(screen_name, "_fetch_single_screen_name_lookup", 
+                                               lambda: self._fetch_single_screen_name_lookup(screen_name))
 
             if self._is_account_locked(response):
                 raise SystemExit("Account locked - terminating process")
@@ -574,8 +577,8 @@ class TwitterAPI:
 
             # 認証エラー検出
             if response.status_code == 401:
-                print(f"  認証エラー検出 ({screen_name}): Cookieが無効です。処理を終了します")
-                raise SystemExit("Authentication failed - Cookie is invalid")
+                return self._handle_auth_error(screen_name, "_fetch_single_screen_name", 
+                                               lambda: self._fetch_single_screen_name(screen_name))
 
             # アカウントロック検出
             if self._is_account_locked(response):
@@ -619,8 +622,8 @@ class TwitterAPI:
 
             # 認証エラー検出
             if response.status_code == 401:
-                print(f"認証エラー検出 (block): Cookieが無効です。処理を終了します")
-                raise SystemExit("Authentication failed - Cookie is invalid")
+                return self._handle_auth_error(f"block {screen_name}", "block_user", 
+                                               lambda: self.block_user(user_id, screen_name))
 
             # アカウントロック検出
             if self._is_account_locked(response):
@@ -993,4 +996,37 @@ class TwitterAPI:
             return None
         except Exception:
             return None
+
+    def _handle_auth_error(self, identifier: str, method_name: str, retry_func):
+        """認証エラーをハンドリングし、クッキーを再読み込みして再試行"""
+        if self._auth_retry_count < self._max_auth_retries:
+            self._auth_retry_count += 1
+            print(f"認証エラー検出 ({identifier}): Cookieを再読み込みして再試行します... (試行 {self._auth_retry_count}/{self._max_auth_retries})")
+            
+            # ログインユーザーIDのキャッシュをクリア
+            self._login_user_id = None
+            
+            # クッキーを再読み込み
+            try:
+                # クッキーキャッシュをクリア
+                self.cookie_manager.clear_cache()
+                # 少し待機してから再試行
+                time.sleep(2)
+                
+                # 再試行
+                result = retry_func()
+                
+                # 成功したらカウンターをリセット
+                self._auth_retry_count = 0
+                return result
+                
+            except SystemExit:
+                # 再試行でも失敗した場合は元のエラーを再発生
+                raise
+            except Exception as e:
+                print(f"クッキー再読み込みエラー ({identifier}): {e}")
+                
+        # 再試行回数を超えた場合、または再試行でも失敗した場合
+        print(f"認証エラー検出 ({identifier}): Cookieが無効です。処理を終了します")
+        raise SystemExit("Authentication failed - Cookie is invalid")
 

--- a/twitter_blocker/config.py
+++ b/twitter_blocker/config.py
@@ -84,9 +84,14 @@ class CookieManager:
 
     def __init__(self, cookies_file: str):
         self.cookies_file = cookies_file
+        self._cookies_cache = None
 
     def load_cookies(self) -> Dict[str, str]:
         """クッキーファイルを読み込み、Twitterドメインのクッキーのみ抽出"""
+        # キャッシュがあればそれを返す
+        if self._cookies_cache is not None:
+            return self._cookies_cache
+        
         with open(self.cookies_file, "r", encoding="utf-8") as f:
             cookies_list = json.load(f)
 
@@ -96,4 +101,9 @@ class CookieManager:
             if domain in self.TWITTER_DOMAINS:
                 cookies_dict[cookie["name"]] = cookie["value"]
 
+        self._cookies_cache = cookies_dict
         return cookies_dict
+    
+    def clear_cache(self):
+        """クッキーキャッシュをクリアして次回読み込み時にファイルから再読み込みさせる"""
+        self._cookies_cache = None

--- a/twitter_blocker/manager.py
+++ b/twitter_blocker/manager.py
@@ -564,8 +564,8 @@ class BulkBlockManager:
             )
         else:
             error_msg = (
-                block_result["error_message"][:200]
-                if block_result["error_message"]
+                block_result["message"][:200]
+                if block_result["message"]
                 else "Unknown error"
             )
             print(f"  ✗ ブロック失敗: {block_result['status_code']} - {error_msg}")
@@ -575,7 +575,7 @@ class BulkBlockManager:
             if self.retry_manager.should_retry(
                 user_status,
                 block_result["status_code"],
-                block_result["error_message"],
+                block_result["message"],
                 0,
             ):
                 print("    → リトライ対象として記録")
@@ -586,7 +586,7 @@ class BulkBlockManager:
                     user_info["name"],
                     False,
                     block_result["status_code"],
-                    block_result["error_message"],
+                    block_result["message"],
                     user_status,
                     0,
                 )
@@ -599,7 +599,7 @@ class BulkBlockManager:
                     user_info["name"],
                     False,
                     block_result["status_code"],
-                    f"{block_result['error_message']} (permanent)",
+                    f"{block_result['message']} (permanent)",
                     user_status,
                     0,
                 )


### PR DESCRIPTION
## Summary
- 401認証エラー検出時に、自動でクッキーをJSONファイルから再読み込みして1回再試行する機能を追加
- CookieManagerにキャッシュ機能を実装し、必要に応じてクリアして再読み込みできるように改善
- 全てのAPI呼び出しで統一的な認証エラーハンドリングを実装

## Test plan
- [ ] 有効なクッキーで正常に動作することを確認
- [ ] 無効なクッキーで401エラーが発生した際に、再読み込み・再試行が行われることを確認
- [ ] 再試行でも失敗した場合に適切にエラー終了することを確認
- [ ] クッキーの再読み込みが正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)