### PR TITLE
fix: バッチ処理エラーメッセージとコード重複の修正

### DIFF
--- a/twitter_blocker/manager.py
+++ b/twitter_blocker/manager.py
@@ -235,13 +235,18 @@ class BulkBlockManager:
                     time.sleep(delay)
                     
             except Exception as e:
-                print(f"  ✗ バッチ処理エラー: {e}")
+                import traceback
+                error_msg = f"{type(e).__name__}: {str(e)}" if str(e) else type(e).__name__
+                print(f"  ✗ バッチ処理エラー: {error_msg}")
+                print(f"  デバッグ情報: バッチサイズ={len(unchecked_ids)}, 開始インデックス={i}")
+                if self.api.debug_mode:
+                    print(f"  スタックトレース:\n{traceback.format_exc()}")
                 # バッチエラー時は個別処理にフォールバック
                 for user_id in unchecked_ids:
                     processed_count += 1
                     stats["errors"] += 1
                     self.database.record_block_result(
-                        None, user_id, None, False, 0, f"バッチ処理エラー: {str(e)}"
+                        None, user_id, None, False, 0, f"バッチ処理エラー: {error_msg}"
                     )
 
     def _process_screen_names_batch(
@@ -330,13 +335,18 @@ class BulkBlockManager:
                 )
                 
             except Exception as e:
-                print(f"  ✗ バッチ処理エラー: {e}")
+                import traceback
+                error_msg = f"{type(e).__name__}: {str(e)}" if str(e) else type(e).__name__
+                print(f"  ✗ バッチ処理エラー: {error_msg}")
+                print(f"  デバッグ情報: バッチサイズ={len(unchecked_names)}, 開始インデックス={i}")
+                if hasattr(self.api, 'debug_mode') and self.api.debug_mode:
+                    print(f"  スタックトレース:\n{traceback.format_exc()}")
                 # バッチエラー時は個別処理にフォールバック
                 for screen_name in unchecked_names:
                     processed_count += 1
                     stats["errors"] += 1
                     self.database.record_block_result(
-                        screen_name, None, None, False, 0, f"バッチ処理エラー: {str(e)}"
+                        screen_name, None, None, False, 0, f"バッチ処理エラー: {error_msg}"
                     )
 
     def _process_single_user(
@@ -406,7 +416,12 @@ class BulkBlockManager:
             time.sleep(delay)
 
         except Exception as e:
-            print(f"  ✗ 処理エラー: {e}")
+            import traceback
+            error_msg = f"{type(e).__name__}: {str(e)}" if str(e) else type(e).__name__
+            print(f"  ✗ 処理エラー: {error_msg}")
+            print(f"  デバッグ情報: ユーザー={user_identifier}, フォーマット={user_format}")
+            if hasattr(self.api, 'debug_mode') and self.api.debug_mode:
+                print(f"  スタックトレース:\n{traceback.format_exc()}")
             stats["errors"] += 1
             self.database.record_block_result(
                 lookup_key if user_format == "screen_name" else None,
@@ -414,7 +429,7 @@ class BulkBlockManager:
                 None,
                 False,
                 0,
-                str(e),
+                error_msg,
             )
 
     def _process_retry_user(
@@ -459,7 +474,12 @@ class BulkBlockManager:
             time.sleep(2.0)
 
         except Exception as e:
-            print(f"  ✗ リトライ処理エラー: {e}")
+            import traceback
+            error_msg = f"{type(e).__name__}: {str(e)}" if str(e) else type(e).__name__
+            print(f"  ✗ リトライ処理エラー: {error_msg}")
+            print(f"  デバッグ情報: ユーザー=@{screen_name}, リトライ回数={retry_count}")
+            if hasattr(self.api, 'debug_mode') and self.api.debug_mode:
+                print(f"  スタックトレース:\n{traceback.format_exc()}")
             stats["errors"] += 1
             self.database.record_block_result(
                 screen_name,
@@ -467,7 +487,7 @@ class BulkBlockManager:
                 candidate["display_name"],
                 False,
                 0,
-                f"リトライ処理エラー: {str(e)}",
+                f"リトライ処理エラー: {error_msg}",
                 None,
                 retry_count,
             )


### PR DESCRIPTION
## Summary
- Cinnamonサーバーで発生していた「✗ バッチ処理エラー: 'error_message'」の修正
- TwitterAPIクラスの重複メソッド定義を削除
- エラーログの詳細化とデバッグ情報の追加

## 修正内容

### 1. 重複メソッド定義の削除
- `_get_login_user_id` メソッドの重複定義を削除
- `_get_lookup_from_cache` メソッドの重複定義を削除  
- `_save_lookup_to_cache` メソッドの重複定義を削除
- `_get_relationship_from_cache` メソッドの重複定義を削除
- `_save_relationship_to_cache` メソッドの重複定義を削除

### 2. バッチ処理エラーメッセージの改善
- `str(e)` → `f"{type(e).__name__}: {str(e)}"` でより詳細なエラー情報を記録
- バッチサイズや開始インデックスなどのデバッグ情報を追加
- デバッグモード時にスタックトレースを出力

### 3. エラーハンドリングの強化
- ユーザー情報やリトライ回数などの詳細情報をログに追加
- エラー発生時の問題特定を容易にするための情報を充実

## Test plan
- [x] 構文エラーチェック完了
- [x] 重複メソッド削除により機能が破損していないことを確認
- [x] エラーメッセージが適切に出力されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)