### PR TITLE
feat: suspended/削除済みアカウントの再取得を防止

### DIFF
--- a/twitter_blocker/database.py
+++ b/twitter_blocker/database.py
@@ -464,30 +464,29 @@ class DatabaseManager:
         """永続的失敗アカウントかどうかをチェック"""
         from .retry import RetryManager
         
-        conn = sqlite3.connect(self.db_file)
-        cursor = conn.cursor()
+        with sqlite3.connect(self.db_file) as conn:
+            cursor = conn.cursor()
 
-        if user_format == "user_id":
-            cursor.execute(
-                """
-                SELECT user_status, response_code, error_message, retry_count
-                FROM block_history 
-                WHERE user_id = ? AND status = 'failed'
-            """,
-                (str(identifier),),
-            )
-        else:
-            cursor.execute(
-                """
-                SELECT user_status, response_code, error_message, retry_count
-                FROM block_history 
-                WHERE screen_name = ? AND status = 'failed'
-            """,
-                (str(identifier),),
-            )
+            if user_format == "user_id":
+                cursor.execute(
+                    """
+                    SELECT user_status, response_code, error_message, retry_count
+                    FROM block_history 
+                    WHERE user_id = ? AND status = 'failed'
+                """,
+                    (str(identifier),),
+                )
+            else:
+                cursor.execute(
+                    """
+                    SELECT user_status, response_code, error_message, retry_count
+                    FROM block_history 
+                    WHERE screen_name = ? AND status = 'failed'
+                """,
+                    (str(identifier),),
+                )
 
-        result = cursor.fetchone()
-        conn.close()
+            result = cursor.fetchone()
 
         if not result:
             return False
@@ -505,32 +504,31 @@ class DatabaseManager:
 
     def get_permanent_failure_info(self, identifier: str, user_format: str = "screen_name") -> Optional[Dict[str, Any]]:
         """永続的失敗アカウントの詳細情報を取得"""
-        conn = sqlite3.connect(self.db_file)
-        cursor = conn.cursor()
+        with sqlite3.connect(self.db_file) as conn:
+            cursor = conn.cursor()
 
-        if user_format == "user_id":
-            cursor.execute(
-                """
-                SELECT screen_name, user_id, display_name, user_status, 
-                       response_code, error_message, retry_count, blocked_at
-                FROM block_history 
-                WHERE user_id = ? AND status = 'failed'
-            """,
-                (str(identifier),),
-            )
-        else:
-            cursor.execute(
-                """
-                SELECT screen_name, user_id, display_name, user_status, 
-                       response_code, error_message, retry_count, blocked_at
-                FROM block_history 
-                WHERE screen_name = ? AND status = 'failed'
-            """,
-                (str(identifier),),
-            )
+            if user_format == "user_id":
+                cursor.execute(
+                    """
+                    SELECT screen_name, user_id, display_name, user_status, 
+                           response_code, error_message, retry_count, blocked_at
+                    FROM block_history 
+                    WHERE user_id = ? AND status = 'failed'
+                """,
+                    (str(identifier),),
+                )
+            else:
+                cursor.execute(
+                    """
+                    SELECT screen_name, user_id, display_name, user_status, 
+                           response_code, error_message, retry_count, blocked_at
+                    FROM block_history 
+                    WHERE screen_name = ? AND status = 'failed'
+                """,
+                    (str(identifier),),
+                )
 
-        result = cursor.fetchone()
-        conn.close()
+            result = cursor.fetchone()
 
         if not result:
             return None
@@ -549,6 +547,73 @@ class DatabaseManager:
             "blocked_at": blocked_at,
             "permanent_failure": True
         }
+
+    def get_permanent_failures_batch(self, identifiers: List[str], user_format: str = "screen_name") -> Dict[str, Dict[str, Any]]:
+        """複数の永続的失敗アカウントを一括取得"""
+        from .retry import RetryManager
+        
+        if not identifiers:
+            return {}
+        
+        retry_manager = RetryManager()
+        results = {}
+        
+        with sqlite3.connect(self.db_file) as conn:
+            cursor = conn.cursor()
+            
+            # プレースホルダーを準備
+            placeholders = ",".join("?" * len(identifiers))
+            str_identifiers = [str(id_) for id_ in identifiers]
+            
+            if user_format == "user_id":
+                query = f"""
+                    SELECT user_id, screen_name, display_name, user_status, 
+                           response_code, error_message, retry_count, blocked_at
+                    FROM block_history 
+                    WHERE user_id IN ({placeholders}) AND status = 'failed'
+                """
+            else:
+                query = f"""
+                    SELECT screen_name, user_id, display_name, user_status, 
+                           response_code, error_message, retry_count, blocked_at
+                    FROM block_history 
+                    WHERE screen_name IN ({placeholders}) AND status = 'failed'
+                """
+            
+            cursor.execute(query, str_identifiers)
+            rows = cursor.fetchall()
+        
+        # 結果を処理
+        for row in rows:
+            if user_format == "user_id":
+                user_id, screen_name, display_name, user_status, response_code, error_message, retry_count, blocked_at = row
+                key = user_id
+            else:
+                screen_name, user_id, display_name, user_status, response_code, error_message, retry_count, blocked_at = row
+                key = screen_name
+            
+            # RetryManagerで永続的失敗かどうかを判定
+            is_permanent = not retry_manager.should_retry(
+                user_status or "unknown",
+                response_code or 0,
+                error_message or "",
+                retry_count or 0
+            )
+            
+            if is_permanent:
+                results[key] = {
+                    "screen_name": screen_name,
+                    "user_id": user_id,
+                    "display_name": display_name,
+                    "user_status": user_status or "unknown",
+                    "response_code": response_code,
+                    "error_message": error_message,
+                    "retry_count": retry_count,
+                    "blocked_at": blocked_at,
+                    "permanent_failure": True
+                }
+        
+        return results
 
     def _get_retry_delay(self, retry_count: int, base_delay: int = 30) -> int:
         """リトライ間隔を計算（指数バックオフ）"""


### PR DESCRIPTION
## Summary
suspendedや削除済みアカウントの無駄なAPI呼び出しを削減し、処理効率を改善する機能を追加しました。

### 主な変更
- **データベース機能追加**: 永続的失敗アカウントの判定・情報取得機能
- **Manager処理改善**: API呼び出し前の事前チェック機能
- **ログ出力改善**: 既知の失敗を明確に区別して表示

### 技術的詳細
- `is_permanent_failure()`: RetryManagerのロジックを使用して永続的失敗を判定
- `get_permanent_failure_info()`: データベースから既知の失敗情報を取得
- バッチ処理・単体処理・リトライ処理の全ての箇所で事前チェックを実装

### 期待される効果
- API呼び出し回数削減による処理速度向上
- エラーメッセージ削減によりログがクリーンに
- suspendedアカウントの無駄な再試行を防止

## Test plan
- [x] 永続的失敗検出機能のユニットテスト
- [x] RetryManagerロジックとの整合性確認
- [x] 構文チェック完了

🤖 Generated with [Claude Code](https://claude.ai/code)