### PR TITLE
fix: KeyError対策でblock_result error_message安全アクセス実装

### DIFF
--- a/twitter_blocker/manager.py
+++ b/twitter_blocker/manager.py
@@ -637,8 +637,8 @@ class BulkBlockManager:
             )
         else:
             error_msg = (
-                block_result["error_message"][:200]
-                if block_result["error_message"]
+                block_result.get("error_message", "Unknown error")[:200]
+                if block_result.get("error_message")
                 else "Unknown error"
             )
             print(f"  ✗ ブロック失敗: {block_result['status_code']} - {error_msg}")
@@ -648,7 +648,7 @@ class BulkBlockManager:
             if self.retry_manager.should_retry(
                 user_status,
                 block_result["status_code"],
-                block_result["error_message"],
+                block_result.get("error_message", "Unknown error"),
                 0,
             ):
                 print("    → リトライ対象として記録")
@@ -659,7 +659,7 @@ class BulkBlockManager:
                     user_info["name"],
                     False,
                     block_result["status_code"],
-                    block_result["error_message"],
+                    block_result.get("error_message", "Unknown error"),
                     user_status,
                     0,
                 )
@@ -672,7 +672,7 @@ class BulkBlockManager:
                     user_info["name"],
                     False,
                     block_result["status_code"],
-                    f"{block_result['error_message']} (permanent)",
+                    f"{block_result.get('error_message', 'Unknown error')} (permanent)",
                     user_status,
                     0,
                 )


### PR DESCRIPTION
## Summary
Cinnamonサーバーで発生している`KeyError: 'error_message'`バッチ処理エラーを解消

## 問題
- Cinnamonサーバー監視で継続的に`KeyError: 'error_message'`エラーが発生
- `block_result`辞書に`error_message`キーが存在しない場合の処理が不適切
- バッチ処理が個別処理にフォールバックする原因となっていた

## 修正内容
### twitter_blocker/manager.py
- **640行**: エラーメッセージ生成部分を`block_result.get("error_message", "Unknown error")`に変更
- **651行**: リトライ判定部分を安全アクセスに変更
- **662,675行**: ブロック結果記録部分を安全アクセスに変更

## 効果
- `KeyError: 'error_message'`エラーの完全解消
- バッチ処理の安定性向上
- Cinnamonサーバーでのエラー率減少

## Test plan
- [x] コード品質チェック: `python3 -m py_compile twitter_blocker/manager.py`
- [ ] Cinnamonサーバーでの動作確認
- [ ] KeyErrorの発生確認（解消されていること）
- [ ] バッチ処理の正常動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)