### PR TITLE
fix: Cinnamonサーバー監視の完了率表示を正確な説明に修正

### DIFF
--- a/.claude/commands/check-cinnamon
+++ b/.claude/commands/check-cinnamon
@@ -116,7 +116,7 @@ if [ -n "$STOPPED_CONTAINERS" ]; then
         case $EXIT_CODE in
             0)
                 if [ -n "$COMPLETION_MSG" ]; then
-                    echo "    ✅ 正常完了 - 全ユーザー処理済み"
+                    echo "    ✅ 処理完了 - 全処理対象が完了（ブロック成功 + 技術的にブロック不可能なユーザー）"
                 else
                     echo "    ✅ 正常終了 - 処理対象完了"
                 fi


### PR DESCRIPTION
## 概要
Cinnamonサーバー監視システムの完了率表示において、83.3%での正常完了について誤解を招く表現を修正しました。

## 問題の背景
- book000_vrcとihc_amotが83.3%完了で「全ユーザー処理済み」と表示されていた
- 実際は83.3%がブロック成功、16.7%が永続的失敗（suspended/not_found/deactivated）
- 永続的失敗は技術的にブロック不可能なため、実質的には100%完了

## 修正内容
停止理由の表示を以下のように変更：
- **修正前**: `正常完了 - 全ユーザー処理済み`
- **修正後**: `処理完了 - 全処理対象が完了（ブロック成功 + 技術的にブロック不可能なユーザー）`

## 技術的詳細
永続的失敗の分類（twitter-bulk-blockerの設計仕様）：
- `suspended`: Twitter/Xに凍結済み
- `not_found`: 既に削除されたアカウント
- `deactivated`: ユーザーが無効化済み

これらは技術的にブロック不可能であり、システム設計上「処理済み」として扱われます。

## テスト内容
- 修正したスクリプトの構文確認
- 表示メッセージの正確性確認

## チェックリスト
- [x] 誤解を招く表現を修正
- [x] 正確な完了率の説明を追加
- [x] twitter-bulk-blockerの設計思想と整合性確認

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>