### PR TITLE
fix: response_code=NullでリトライされないUnhandledな失敗の修正

### DIFF
--- a/twitter_blocker/database.py
+++ b/twitter_blocker/database.py
@@ -242,10 +242,12 @@ class DatabaseManager:
             AND (
                 user_status IN ('unavailable') OR
                 response_code IN (429, 500, 502, 503, 504) OR
+                response_code IS NULL OR
                 error_message LIKE '%temporarily%' OR
                 error_message LIKE '%rate limit%' OR
                 error_message LIKE '%timeout%' OR
-                error_message LIKE '%server error%'
+                error_message LIKE '%server error%' OR
+                error_message LIKE '%ユーザー情報取得失敗%'
             )
             ORDER BY last_retry_at ASC
         """

--- a/twitter_blocker/retry.py
+++ b/twitter_blocker/retry.py
@@ -60,7 +60,7 @@ class RetryManager:
             return True
 
         # HTTPステータスコードによる判定
-        if status_code in self.RETRYABLE_STATUS_CODES:
+        if status_code and status_code in self.RETRYABLE_STATUS_CODES:
             return True
 
         # エラーメッセージによる判定
@@ -69,6 +69,14 @@ class RetryManager:
             for msg in self.RETRYABLE_MESSAGES:
                 if msg in error_lower:
                     return True
+            
+            # 日本語エラーメッセージの判定
+            if "ユーザー情報取得失敗" in error_message:
+                return True
+
+        # status_codeがNullで特定のエラーパターンでない場合はリトライ対象
+        if status_code is None and error_message and "permanent" not in error_message.lower():
+            return True
 
         return False
 


### PR DESCRIPTION
## 概要
response_code=Nullの失敗ユーザー（26,860件）がリトライ候補から除外されていた重要な不具合を修正

## 🚨 問題の詳細
Cinnamonサーバーでの詳細調査により以下の問題を発見：
- **26,860件の失敗ユーザー**がresponse_code=Nullでリトライ回数0のまま放置
- `get_retry_candidates()`のSQL WHERE条件にresponse_code IS NULLが含まれていない
- これにより「実質未処理」として大量のユーザーが残存していた

### データベース分析結果
```
ステータス: failed, レスポンス: None, リトライ: 0, 件数: 26860
ステータス: failed, レスポンス: 404, リトライ: 0, 件数: 23
ステータス: failed, レスポンス: 0, リトライ: 0, 件数: 1
```

## 🔧 修正内容

### 1. database.py: get_retry_candidates()の修正
- `response_code IS NULL` 条件を追加
- `error_message LIKE '%ユーザー情報取得失敗%'` 条件を追加

### 2. retry.py: should_retry()メソッドの改善
- response_code=Noneケースの明示的な処理を追加
- 日本語エラーメッセージ「ユーザー情報取得失敗」の判定を追加
- permanentエラー以外のNullレスポンスをリトライ対象に包含

## ✅ テスト結果
```python
テスト1 (response_code=None, ユーザー情報取得失敗): True
テスト2 (response_code=None, permanent): False
テスト3 (429エラー): True
テスト4 (suspended): False
```

## 📈 期待される効果
- **26,860件の未処理ユーザー**がリトライ対象になる
- 完了率の大幅改善（83.3% → より高い率へ）
- 「実質未処理」の大幅減少
- システムの自動復旧能力向上

## 🔄 影響範囲
- 既存の正常なリトライロジックには影響なし
- 新たにリトライ対象となるのは主にAPI情報取得失敗のケース
- 永続的失敗は適切に除外される

## チェックリスト
- [x] ローカルでコンパイルエラーなし
- [x] リトライロジックのテスト実行
- [x] 既存機能への影響確認
- [x] 26,860件の未処理問題の根本解決

Fixes #45

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>