### PR TITLE
fix: About an hour稼働時間パース問題の修正

### DIFF
--- a/.claude/commands/check-cinnamon
+++ b/.claude/commands/check-cinnamon
@@ -430,13 +430,21 @@ CONTAINER_UPTIME_INFO=$(ssh Cinnamon "docker ps --format 'table {{.Names}}\t{{.S
 if [ -n "$CONTAINER_UPTIME_INFO" ]; then
     # 稼働時間テキストから時間を抽出・解析（改良版）
     # Statusフィールド全体を取得（例: "Up 3 hours (healthy)" → "Up 3 hours"）
+    # "Up About an hour"形式にも対応
     UPTIME_TEXT=$(echo "$CONTAINER_UPTIME_INFO" | sed 's/.*\(Up [^(]*\).*/\1/' | sed 's/[[:space:]]*$//')
     
     # 稼働時間の秒数への変換（改良版：複数の形式に対応）
+    # 重要: "About"形式を数値形式より先にチェック
     UPTIME_SECONDS=0
     
+    # "Up About an hour"形式（最優先）
+    if echo "$UPTIME_TEXT" | grep -q "About an hour"; then
+        UPTIME_SECONDS=3600
+    # "Up About a minute"形式
+    elif echo "$UPTIME_TEXT" | grep -q "About a minute"; then
+        UPTIME_SECONDS=60
     # "Up X seconds"形式
-    if echo "$UPTIME_TEXT" | grep -q "second"; then
+    elif echo "$UPTIME_TEXT" | grep -q "second"; then
         UPTIME_SECONDS=$(echo "$UPTIME_TEXT" | grep -o '[0-9]\+' | head -1)
     # "Up X minutes"形式
     elif echo "$UPTIME_TEXT" | grep -q "minute"; then
@@ -450,12 +458,6 @@ if [ -n "$CONTAINER_UPTIME_INFO" ]; then
     elif echo "$UPTIME_TEXT" | grep -q "day"; then
         UPTIME_DAYS=$(echo "$UPTIME_TEXT" | grep -o '[0-9]\+' | head -1)
         UPTIME_SECONDS=$((UPTIME_DAYS * 86400))
-    # "Up About a minute"形式
-    elif echo "$UPTIME_TEXT" | grep -q "About a minute"; then
-        UPTIME_SECONDS=60
-    # "Up About an hour"形式
-    elif echo "$UPTIME_TEXT" | grep -q "About an hour"; then
-        UPTIME_SECONDS=3600
     # その他の特殊ケース（フォールバック）
     else
         # 数値が含まれているかチェック


### PR DESCRIPTION
## 問題の概要
1時間稼働時に`About an hour`形式の稼働時間が正しくパースされず、0秒として処理される問題が発生

## 🐛 発生していた問題
```bash
⏱️ 現在の稼働時間: Up About an hour (0秒) ← パースエラー
🏆 マイルストーン: ⏳ 短期稼働 ← 誤判定
📊 品質レベル: INITIAL ← 実際はEXCELLENT級
```

## 🔧 根本原因
条件分岐の順序問題：
1. `"Up About an hour"`が`"hour"`にマッチ
2. 数値抽出`grep -o '[0-9]+'`で数値なしのため失敗
3. 結果として0秒と判定

## 💡 修正内容

### Before: 誤った条件分岐順序
```bash
# "Up X hours"形式（先にマッチ）
elif echo "$UPTIME_TEXT"  < /dev/null |  grep -q "hour"; then
    UPTIME_HOURS=$(echo "$UPTIME_TEXT" | grep -o '[0-9]\+' | head -1)  # 失敗
    UPTIME_SECONDS=$((UPTIME_HOURS * 3600))
# "Up About an hour"形式（到達せず）
elif echo "$UPTIME_TEXT" | grep -q "About an hour"; then
    UPTIME_SECONDS=3600
```

### After: 正しい優先順位
```bash
# "Up About an hour"形式（最優先）
if echo "$UPTIME_TEXT" | grep -q "About an hour"; then
    UPTIME_SECONDS=3600
# "Up About a minute"形式
elif echo "$UPTIME_TEXT" | grep -q "About a minute"; then
    UPTIME_SECONDS=60
# "Up X hours"形式（数値形式）
elif echo "$UPTIME_TEXT" | grep -q "hour"; then
    UPTIME_HOURS=$(echo "$UPTIME_TEXT" | grep -o '[0-9]\+' | head -1)
    UPTIME_SECONDS=$((UPTIME_HOURS * 3600))
```

## 📊 修正結果

### After: 正常な動作
```bash
⏱️ 現在の稼働時間: Up About an hour (3600秒)
🏆 マイルストーン: 🎯 1時間+ EXCELLENT
📊 品質レベル: EXCELLENT
⏰ 推奨監視間隔: 60-120分
🆕 新記録達成！ 前回最高: 3060秒 → 現在: 3600秒
```

## 🎯 影響・効果
- **1時間稼働の正確な認識**: EXCELLENT品質レベルの適切な判定
- **監視間隔最適化**: 60-120分の適切な推奨間隔
- **マイルストーン記録**: 正確な稼働時間記録と新記録検出
- **403エラー問題追跡**: 1時間経過時点での正確な評価が可能

## テスト結果
- ✅ `About an hour`形式で3600秒に正確変換
- ✅ EXCELLENT品質レベル認定
- ✅ 新記録検出機能の正常動作
- ✅ 他の時間形式との互換性維持

この修正により、1時間稼働時の状態が正確に評価され、Issue #71の403エラー問題追跡において重要なマイルストーンデータが適切に記録されるようになりました。

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>