### PR TITLE
hotfix: 403エラー無限ループの追加修正 - Cookie更新時の強制リセット

### DIFF
--- a/twitter_blocker/api.py
+++ b/twitter_blocker/api.py
@@ -1235,8 +1235,13 @@ class TwitterAPI:
             self._403_error_stats["classified_errors"][error_type] += 1
             
             # 403エラー専用処理：Cookie強制更新（無限ループ防止）
+            def reset_403_errors():
+                """403エラー統計の強制リセット"""
+                self._403_error_stats["total_403_errors"] = 0
+                self._403_error_stats["classified_errors"] = {}
+                
             if self.cookie_manager.force_refresh_on_error_threshold(
-                self._403_error_stats["total_403_errors"], threshold=5):
+                self._403_error_stats["total_403_errors"], threshold=5, reset_callback=reset_403_errors):
                 print(f"🔄 403エラー蓄積による強制リトライ対象: {action_name}")
                 # Cookie更新後の待機時間を追加（無限ループ防止）
                 import time

--- a/twitter_blocker/config.py
+++ b/twitter_blocker/config.py
@@ -153,11 +153,20 @@ class CookieManager:
         self._cache_timestamp = None
         self._file_mtime = None
     
-    def force_refresh_on_error_threshold(self, error_count: int, threshold: int = 5) -> bool:
+    def force_refresh_on_error_threshold(self, error_count: int, threshold: int = 5, reset_callback=None) -> bool:
         """403エラーが閾値を超えた場合の強制Cookie更新（無限ループ防止）"""
         if error_count >= threshold:
             print(f"🚨 403エラー{error_count}回検出: Cookie強制更新実行（閾値: {threshold}）")
             self.clear_cache()
+            
+            # Cookie更新時に403エラーカウンターを強制リセット
+            if reset_callback and callable(reset_callback):
+                try:
+                    reset_callback()
+                    print("🔄 403エラーカウンター強制リセット完了（Cookie更新時）")
+                except Exception as e:
+                    print(f"⚠️ 403エラーカウンターリセット失敗: {e}")
+                    
             return True
         return False
     


### PR DESCRIPTION
## 🚨 緊急修正概要

**問題**: PR #81の修正後も403エラー無限ループが再発（145件/10分）

**根本原因**: ブロック成功が0件のため、成功時のエラーカウンターリセットが動作しない

## 📋 修正内容

### 1. Cookie更新時の強制403エラーリセット実装
- **config.py**: `force_refresh_on_error_threshold`に`reset_callback`パラメータ追加
- **api.py**: Cookie更新時に403エラー統計を強制リセットする仕組み実装

### 2. 成功処理に依存しないリセット機能
- Cookie更新タイミングで確実にエラーカウンターをリセット
- 無限ループを根本的に防止

## 🎯 解決される問題

- ✅ book000コンテナの145件/10分の403エラー無限ループ
- ✅ 成功処理がない場合のエラーカウンター蓄積
- ✅ Cookie更新後の適切なリセット処理

## 🧪 テスト内容

- [x] ローカルでのコンパイルチェック
- [x] 修正内容の論理的整合性確認
- [ ] book000コンテナでの実動作確認（デプロイ後）
- [ ] 無限ループ停止の確認（デプロイ後）

## 🚀 デプロイ後の確認項目

1. book000コンテナの403エラー数減少確認
2. エラーカウンターリセットメッセージの出力確認
3. システム安定性の継続監視

Closes #82

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>