### PR TITLE
chore: add .worktreeinclude for local credential and data files

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,13 @@
+.env
+cookies.json
+*.cookies.json
+cookies_*.json
+video_misuse_detecteds.json
+*_users.json
+users_*.json
+block_targets.json
+target_users.json
+block_history.db
+*.db
+*.sqlite
+*.sqlite3


### PR DESCRIPTION
## 概要

新規 git worktree でもローカルの認証情報・データファイルを引き継げるよう、`.worktreeinclude` を追加しました。

## 追加したパターン

```
.env
cookies.json
*.cookies.json
cookies_*.json
video_misuse_detecteds.json
*_users.json
users_*.json
block_targets.json
target_users.json
block_history.db
*.db
*.sqlite
*.sqlite3
```

## 根拠（Phase 1 調査結果より抜粋）

- `.env.example` がリポジトリルートに存在し、「このファイルを `.env` にコピーして使用してください」と明記されている。
- `.gitignore` は `.env` 系に加え、プロジェクト固有の `cookies.json`、`*.cookies.json`、`cookies_*.json`、`video_misuse_detecteds.json`、`*_users.json`、`users_*.json`、`block_targets.json`、`target_users.json`、`block_history.db`、`*.db`、`*.sqlite`、`*.sqlite3` を無視している。
- README.md では `cookies.json`(X.com からエクスポートしたクッキー情報) が必須のローカル認証情報ファイルとして説明されている。
- README.md には `TWITTER_COOKIES_PATH` 環境変数がローカルの `cookies.json` パスを指す例が複数箇所に記載されている。
- `.env.example` は `TWITTER_COOKIES_PATH`、`TWITTER_USERS_FILE`、`TWITTER_BLOCK_DB` の 3 つのローカル設定値を定義している。

本ツールは CLI であり、`cookies.json`(X.com へのライブログインセッションからのエクスポートが必要) やユーザーリスト JSON、SQLite ブロック履歴 DB はリポジトリのみからは再生成できません。`.worktreeinclude` によって、新しい worktree 作成直後から動作可能な状態を引き継げるようにします。

## 関連

- https://github.com/book000/book000/issues/132
